### PR TITLE
Add Hugging Face integration

### DIFF
--- a/models/clip_dinoiser/clip_dinoiser.py
+++ b/models/clip_dinoiser/clip_dinoiser.py
@@ -14,11 +14,13 @@ from omegaconf import OmegaConf
 
 from models.builder import MODELS, build_model
 
+from huggingface_hub import PyTorchModelHubMixin
+
 NORMALIZE = T.Normalize((0.485, 0.456, 0.406), (0.229, 0.224, 0.225))
 
 
 @MODELS.register_module()
-class DinoCLIP(nn.Module):
+class DinoCLIP(nn.Module, PyTorchModelHubMixin, repo_url="https://github.com/wysoczanska/clip_dinoiser", pipeline_tag="image-segmentation"):
     """
     Base model for all the backbones. Implements CLIP features refinement based on DINO dense features and background
     refinement using FOUND model.


### PR DESCRIPTION
Hi @wysoczanska,

Thanks for this nice work! I discovered it through ECCV/Twitter and indexed the paper page here: https://huggingface.co/papers/2312.12359. The paper page is a new feature on 🤗 which allows people to discuss papers and find related artifacts, such as model checkpoints, datasets and a demo using Gradio.

For now there are no artifacts linked to the paper (I see there's a PyTorch checkpoint present within this Github repository). This PR ensures people can find the model from the paper page, by integrating with the hub. It leverages the PyTorchModelHubMixin class which adds `push_to_hub` and `from_pretrained` methods to any custom `nn.Module`.

This improves discoverability/visibility of your work.

Usage is as follows:

```python
from hydra import compose
from models.builder import build_model
from clip_dinoiser import DinoCLIP

# define model
cfg = compose(config_name='clip_dinoiser.yaml')
prompts = "rusted van,foggy clouds,mountains,green trees" 
model = build_model(cfg.model, class_names=prompts)

# equip with weights
checkpoint = torch.load(args.checkpoint_path, map_location='cpu')
model.load_state_dict(checkpoint['model_state_dict'], strict=False)

# push to the hub
model.push_to_hub("facebook/dino-clip")

# reload
model = DinoCLIP.from_pretrained("facebook/dino-clip")
```

The Mixin pushes a `config.json` along with `safetensors` weights to the hub. 

Would you be interested in this integration?

Kind regards,

Niels